### PR TITLE
Fix env variable for script triggered by cron

### DIFF
--- a/script/cron-cleanup-docker-registry-image.sh
+++ b/script/cron-cleanup-docker-registry-image.sh
@@ -17,7 +17,7 @@ REGISTRY_DATA_DIR=${registryVolume} /root/script/clean_old_versions.py \
                                     --image "${patternImage}" \
                                     -l ${nbTagToKeep} \
                                     --order "${orderBeforeDeletion}" \
-                                    --registry-url ${registryUrl} > /var/log/clean-images-registry.log
+                                    --registry-url ${registryUrl}
 
 podName=$(hostname)
 

--- a/script/set-cron.sh
+++ b/script/set-cron.sh
@@ -3,6 +3,6 @@
 # default each Sunday 0:00
 cronTime="${cronTime:-0 0 * * 0}"
 
-echo "${cronTime} /root/script/cron-cleanup-docker-registry-image.sh 2>&1 > /var/log/clean-images-registry.log" > /etc/crontab
+echo "${cronTime} /bin/bash -l -c '/root/script/cron-cleanup-docker-registry-image.sh 2>&1 > /var/log/clean-images-registry.log'" > /etc/crontab
 crontab /etc/crontab
 /sbin/my_init -- tail -f /var/log/clean-images-registry.log


### PR DESCRIPTION
Cron don't run command with a standard bash environment, so you need to exec the script with "/bin/bash -l" to populate the env variable available into the container.